### PR TITLE
Fix uploads when using ActionDispatch::Http::UploadedFile

### DIFF
--- a/lib/carrierwave/base64/orm/activerecord.rb
+++ b/lib/carrierwave/base64/orm/activerecord.rb
@@ -7,7 +7,7 @@ module Carrierwave
         mount_uploader attribute, uploader_class
 
         define_method "#{attribute}=" do |data|
-          if data.present? && data.strip.end_with?("==")
+          if data.present? && data.is_a?(String) && data.strip.end_with?("==")
             super(Carrierwave::Base64::Base64StringIO.new(data.strip))
           else
             super(data)


### PR DESCRIPTION
I have an `ActiveRecord::Base` class using both `mount_uploader` and `mount_base64_uploader`. Base64 file uploads worked fine however uploading files using form multipart crashed due to this error:

> undefined method `strip' for #<ActionDispatch::Http::UploadedFile:0x0000000f7134a0>
Rails.root: xxxxxxxxxxx
Application Trace | Framework Trace | Full Trace
carrierwave-base64 (1.1) lib/carrierwave/base64/orm/activerecord.rb:10:in `block in mount_base64_uploader'

With this PR I'm preventing calling `strip` method on a  `ActionDispatch::Http::UploadedFile` object by checking first if the parameter is a String.