### PR TITLE
Support for more general file uploads

### DIFF
--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -3,27 +3,27 @@ module Carrierwave
     class Base64StringIO < StringIO
       class ArgumentError < StandardError; end
 
-      attr_accessor :image_format
+      attr_accessor :file_format
 
-      def initialize(encoded_image)
-        description, encoded_bytes = encoded_image.split(",")
+      def initialize(encoded_file)
+        description, encoded_bytes = encoded_file.split(",")
 
         raise ArgumentError unless encoded_bytes
 
-        @image_format = get_image_format description
+        @file_format = get_file_format description
         bytes = ::Base64.decode64 encoded_bytes
 
         super bytes
       end
 
       def original_filename
-        File.basename("image.#{@image_format}")
+        File.basename("file.#{@file_format}")
       end
 
       private
 
-      def get_image_format(description)
-        regex = /\Adata:image\/([a-z]+);base64\z/i
+      def get_file_format(description)
+        regex = /([a-z]+);base64\z/
         regex.match(description).try(:[], 1)
       end
     end

--- a/lib/carrierwave/base64/orm/activerecord.rb
+++ b/lib/carrierwave/base64/orm/activerecord.rb
@@ -7,7 +7,7 @@ module Carrierwave
         mount_uploader attribute, uploader_class
 
         define_method "#{attribute}=" do |data|
-          if data.present? && data.is_a?(String) && data.strip.start_with?("data:image")
+          if data.present? && data.is_a?(String) && data.strip.start_with?("data")
             super(Carrierwave::Base64::Base64StringIO.new(data.strip))
           else
             super(data)

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -6,11 +6,24 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
     subject { described_class.new image_data }
 
     it "determines the image format from the Dara URI scheme" do
-      expect(subject.image_format).to eql("jpg")
+      expect(subject.file_format).to eql("jpg")
     end
 
     it "should respond to :original_filename" do
-      expect(subject.original_filename).to eql("image.jpg")
+      expect(subject.original_filename).to eql("file.jpg")
+    end
+  end
+
+  context "correct pdf data" do
+    let(:image_data) { "data:application/pdf;base64,/9j/4AAQSkZJRgABAQEASABKdhH//2Q==" }
+    subject { described_class.new image_data }
+
+    it "determines the image format from the Dara URI scheme" do
+      expect(subject.file_format).to eql("pdf")
+    end
+
+    it "should respond to :original_filename" do
+      expect(subject.original_filename).to eql("file.pdf")
     end
   end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Carrierwave::Base64::ActiveRecord do
       subject.image = File.read(file_path("fixtures", "base64_image.fixture")).strip
       subject.save!
       subject.reload
-      expect(subject.image.current_path).to eq file_path("../uploads", "image.jpg")
+      expect(subject.image.current_path).to eq file_path("../uploads", "file.jpg")
     end
   end
 end


### PR DESCRIPTION
Initial code made a lot of assumptions that only supported image files, this adds support for more file types such as PDF (which is what I needed). Other formats should just work. Resolves #5 

