### PR TITLE
multi uploads

### DIFF
--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -12,6 +12,22 @@ module Carrierwave
           end
         end
       end
+
+      def mount_base64_uploaders(attribute, uploader_class, options = {})
+        mount_uploaders attribute, uploader_class, options
+
+        define_method "#{attribute}=" do |data|
+          if data.present? && data.is_a?(Array) && data.all? { |d| d.is_a?(String) } && data.all? { |d| d.strip.start_with?("data") }
+            files = []
+            data.each do |d|
+              files << Carrierwave::Base64::Base64StringIO.new(d.strip)
+            end
+            super(files)
+          else
+            super([data])
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This only works with the current ```master``` branch of carrierwave. As it is not possible to add git repos via ```add_dependency```, then it's not possible to write tests (due to the use of ```mount_uploaders``` method that is only present in carrierwave ```master```, then tests will fail). Hence why I am PR'ing to ```dev```