### PR TITLE
Multiple Uploads: Fix bug where I can't send regular files to attribute writter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in carrierwave-base64.gemspec
 gemspec
+gem "carrierwave", github: "carrierwaveuploader/carrierwave"

--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "carrierwave", [">= 0.8.0", "< 0.11.0"]
+  #spec.add_dependency "carrierwave", [">= 0.8.0", "< 0.11.0"]
 
   spec.add_development_dependency "rails", ">= 3.2.0"
   spec.add_dependency "activerecord",  ">= 3.2.0"

--- a/lib/carrierwave/base64.rb
+++ b/lib/carrierwave/base64.rb
@@ -6,7 +6,7 @@ module Carrierwave
   module Base64
     class Railtie < Rails::Railtie
       ActiveSupport.on_load :active_record do
-        ActiveRecord::Base.extend Carrierwave::Base64::Adapter
+        ActiveRecord::Base.include Carrierwave::Base64::Adapter
       end
 
       ActiveSupport.on_load :mongoid do

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -5,27 +5,23 @@ module Carrierwave
         mount_uploader attribute, uploader_class, options
 
         define_method "#{attribute}=" do |data|
-          if data.present? && data.is_a?(String) && data.strip.start_with?("data")
-            super(Carrierwave::Base64::Base64StringIO.new(data.strip))
-          else
-            super(data)
-          end
+          super Carrierwave::Base64::Adapter.handle_data(data)
         end
       end
 
       def mount_base64_uploaders(attribute, uploader_class, options = {})
         mount_uploaders attribute, uploader_class, options
 
-        define_method "#{attribute}=" do |data|
-          if data.present? && data.is_a?(Array) && data.all? { |d| d.is_a?(String) } && data.all? { |d| d.strip.start_with?("data") }
-            files = []
-            data.each do |d|
-              files << Carrierwave::Base64::Base64StringIO.new(d.strip)
-            end
-            super(files)
-          else
-            super([data])
-          end
+        define_method "#{attribute}=" do |data_ary|
+          super data_ary.map(&Carrierwave::Base64::Adapter.method(:handle_data))
+        end
+      end
+
+      def self.handle_data(data)
+        if data.present? && data.is_a?(String) && data.strip.start_with?("data")
+          Carrierwave::Base64::Base64StringIO.new(data.strip)
+        else
+          data
         end
       end
     end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 RSpec.describe Carrierwave::Base64::Adapter do
-  describe ".mount_base64_uploader" do
-    let(:uploader) { Class.new CarrierWave::Uploader::Base }
+  let(:uploader) { Class.new CarrierWave::Uploader::Base }
 
+  describe ".mount_base64_uploader" do
     subject do
       Post.mount_base64_uploader(:image, uploader)
       Post.new
@@ -27,6 +27,29 @@ RSpec.describe Carrierwave::Base64::Adapter do
       subject.save!
       subject.reload
       expect(subject.image.current_path).to eq file_path("../uploads", "file.jpg")
+    end
+  end
+
+  describe ".mount_base64_uploaders" do
+    subject do
+      Post.mount_base64_uploaders(:images, uploader)
+      Post.new
+    end
+
+    it "handles normal file uploads" do
+      sham_rack_app = ShamRack.at('www.example.com').stub
+      sham_rack_app.register_resource("/test.jpg", file_path("fixtures", "test.jpg"), "images/jpg")
+      subject[:images] = ["test.jpg"]
+      subject.save!
+      subject.reload
+      expect(subject.images.first.current_path).to eq file_path("../uploads", "test.jpg")
+    end
+
+    it "handles data-urls" do
+      subject.images = [File.read(file_path("fixtures", "base64_image.fixture")).strip]
+      subject.save!
+      subject.reload
+      expect(subject.images.first.current_path).to eq file_path("../uploads", "file.jpg")
     end
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,2 +1,3 @@
 class Post < ActiveRecord::Base
+  serialize :images, Array
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -3,6 +3,7 @@ ActiveRecord::Schema.define do
 
   create_table "posts", force: :cascade do |t|
     t.string   "image"
+    t.text     "images", array: true, default: []
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
In reference to https://github.com/lebedev-yury/carrierwave-base64/pull/20.

This fixes this:

~~~ruby
class Post
    mount_base64_uploaders :pictures, PictureUploader
end

Post.new pictures: [File.open(...)]
=> TypeError: no implicit conversion of nil into String
~~~
... so you can mix regular files and base64 strings. Also I added some tests, although the depend on installing carrierwave from master branch at github.