### PR TITLE
Add JSON String support in mount_base64_uploaders and also some simple tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in carrierwave-base64.gemspec
+
+# multiple file uploader support
+gem 'carrierwave', :git => "https://github.com/carrierwaveuploader/carrierwave"
 gemspec

--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -19,14 +19,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "carrierwave", ">= 0.8.0"
+  spec.add_dependency "carrierwave", [">= 0.8.0", "< 0.12.0"]
+
   spec.add_development_dependency "rails", ">= 3.2.0"
-  spec.add_dependency "activerecord",  ">= 3.2.0"
-  spec.add_dependency "activesupport", ">= 3.2.0"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", ["~> 10.0"]
+  spec.add_development_dependency "rspec", ["~> 2.14"]
   spec.add_development_dependency "sham_rack"
   spec.add_development_dependency "pry"
 end

--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -19,15 +19,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "carrierwave", [">= 0.8.0", "< 0.11.0"]
-
+  spec.add_dependency "carrierwave", ">= 0.8.0"
   spec.add_development_dependency "rails", ">= 3.2.0"
   spec.add_dependency "activerecord",  ">= 3.2.0"
   spec.add_dependency "activesupport", ">= 3.2.0"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", ["~> 10.0"]
-  spec.add_development_dependency "rspec", ["~> 2.14"]
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "sham_rack"
   spec.add_development_dependency "pry"
 end

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -6,6 +6,7 @@ module Carrierwave
 
         define_method "#{attribute}=" do |data|
           if data.present? && data.is_a?(String) && data.strip.start_with?("data")
+            send "#{attribute}_will_change!" if data.present?
             super(Carrierwave::Base64::Base64StringIO.new(data.strip))
           else
             super(data)
@@ -17,12 +18,18 @@ module Carrierwave
         mount_uploaders attribute, uploader_class, options
 
         define_method "#{attribute}=" do |data|
-          if data.present? && data.is_a?(Array) && data.all? { |d| d.is_a?(String) } && data.all? { |d| d.strip.start_with?("data") }
-            files = []
-            data.each do |d|
-              files << Carrierwave::Base64::Base64StringIO.new(d.strip)
-            end
-            super(files)
+          send "#{attribute}_will_change!" if data.present?
+
+          if data.is_a?(Array)
+            base64_data = data
+          elsif data.is_a?(String)
+            base64_data = JSON.parse(data)
+          else
+            base64_data = []
+          end
+
+          if data.present? && base64_data.all? {|d| d.is_a?(String) and d.strip.start_with?("data")}
+            super(base64_data.map{|d| Carrierwave::Base64::Base64StringIO.new(d.strip)})
           else
             super([data])
           end

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -18,7 +18,6 @@ module Carrierwave
         mount_uploaders attribute, uploader_class, options
 
         define_method "#{attribute}=" do |data|
-          send "#{attribute}_will_change!" if data.present?
 
           if data.is_a?(Array)
             base64_data = data
@@ -29,6 +28,7 @@ module Carrierwave
           end
 
           if data.present? && base64_data.all? {|d| d.is_a?(String) and d.strip.start_with?("data")}
+            send "#{attribute}_will_change!" if data.present?
             super(base64_data.map{|d| Carrierwave::Base64::Base64StringIO.new(d.strip)})
           else
             super([data])

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -18,18 +18,18 @@ module Carrierwave
         mount_uploaders attribute, uploader_class, options
 
         define_method "#{attribute}=" do |data|
+          send "#{attribute}_will_change!" if data.present?
 
           if data.is_a?(Array)
             base64_data = data
           elsif data.is_a?(String)
             base64_data = JSON.parse(data)
           else
-            base64_data = []
+            base64_data = nil
           end
 
-          if data.present? && base64_data.all? {|d| d.is_a?(String) and d.strip.start_with?("data")}
-            send "#{attribute}_will_change!" if data.present?
-            super(base64_data.map{|d| Carrierwave::Base64::Base64StringIO.new(d.strip)})
+          if data.present? && base64_data.present?
+            super(base64_data.select{|d| d.strip.start_with?("data")}.map{|d| Carrierwave::Base64::Base64StringIO.new(d.strip)})
           else
             super([data])
           end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -29,4 +29,43 @@ RSpec.describe Carrierwave::Base64::Adapter do
       expect(subject.image.current_path).to eq file_path("../uploads", "file.jpg")
     end
   end
+
+  describe ".mount_base64_uploaders" do
+    let(:uploader) { Class.new CarrierWave::Uploader::Base }
+
+    subject do
+      Post.mount_base64_uploaders(:images, uploader)
+      Post.new
+    end
+
+    it "handles normal file uploads" do
+      sham_rack_app = ShamRack.at('www.example.com').stub
+      sham_rack_app.register_resource("/test.jpg", file_path("fixtures", "test.jpg"), "images/jpg")
+      sham_rack_app.register_resource("/test2.jpg", file_path("fixtures", "test.jpg"), "images/jpg")
+      subject[:images] = ["test.jpg", "test2.jpg"]
+      subject.save!
+      subject.reload
+      expect(subject.images[0].current_path).to eq file_path("../uploads", "test.jpg")
+      expect(subject.images[1].current_path).to eq file_path("../uploads", "test2.jpg")
+    end
+
+    it "mounts the uploaders on the image field" do
+      expect(subject.images).to eq([])
+    end
+
+
+    it "handles data-urls" do
+      subject.images = [File.read(file_path("fixtures", "base64_image.fixture")).strip, File.read(file_path("fixtures", "base64_image.fixture")).strip]
+      subject.save!
+      subject.reload
+      expect(subject.images[1].current_path).to eq file_path("../uploads", "file.jpg")
+    end
+
+    it "handles data-urls strings" do
+      subject.images = "[\"#{File.read(file_path("fixtures", "base64_image.fixture")).strip}\", \"#{File.read(file_path("fixtures", "base64_image.fixture")).strip}\"]"
+      subject.save!
+      subject.reload
+      expect(subject.images[1].current_path).to eq file_path("../uploads", "file.jpg")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require "carrierwave/orm/activerecord"
 require "carrierwave/base64"
 
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+#ActiveRecord::Base.establish_connection adapter: "postgresql", database: "carrierwave-base64-test", username: "USERNAME", password: "YOURPASSWD"
 
 load "support/schema.rb"
 require "support/models"

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -3,6 +3,7 @@ ActiveRecord::Schema.define do
 
   create_table "posts", force: :cascade do |t|
     t.string   "image"
+    t.json     "images"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Here my changes, hope you find them useful:
1. JSON string support in mount_base64_uploaders, for example: produced by JSON.stringify(images).
2. Refactor the code structure of mount_base64_uploaders
3. Modify dependencies to support newer carrierwave and multiple file upload
4. Add tests for mount_base64_uploaders
5. Add dependencies to support the new tests I added for mount_base64_uploaders

Best regards,
Tsung-en Hsiao