### PR TITLE
allow assigning file_name to uploaded file

### DIFF
--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -4,14 +4,40 @@ module Carrierwave
       def mount_base64_uploader(attribute, uploader_class, options = {})
         mount_uploader attribute, uploader_class, options
 
+        if options[:file_name].blank? || options[:file_name] == true
+          options[:file_name] = "#{attribute}_file_name"
+          options[:file_name] = "file_name" if attribute.to_s == 'file'
+        end
+
+        define_method :file_name_field do
+          options[:file_name]
+        end
+
+        attr_accessor options[:file_name]
+
         define_method "#{attribute}=" do |data|
           send "#{attribute}_will_change!" if data.present?
 
           if data.present? && data.is_a?(String) && data.strip.start_with?("data")
-            super(Carrierwave::Base64::Base64StringIO.new(data.strip))
+            data_obj = Carrierwave::Base64::Base64StringIO.new(
+              data.strip, file_name: try(file_name_field)
+            )
+            super(data_obj)
           else
             super(data)
           end
+        end
+
+        define_method 'attributes=' do |new_attributes|
+          # Ensure file_name is assigned before actual file
+          super new_attributes.slice(file_name_field.to_s)
+          super new_attributes
+        end
+
+        define_method 'assign_attributes' do |new_attributes|
+          # Ensure file_name is assigned before actual file
+          super new_attributes.slice(file_name_field.to_s)
+          super new_attributes
         end
       end
     end

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -3,22 +3,23 @@ module Carrierwave
     class Base64StringIO < StringIO
       class ArgumentError < StandardError; end
 
-      attr_accessor :file_format
+      attr_accessor :file_format, :file_name
 
-      def initialize(encoded_file)
+      def initialize(encoded_file, options = {})
         description, encoded_bytes = encoded_file.split(",")
 
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?("(null)")
 
         @file_format = get_file_format description
+        @file_name = options[:file_name].try(:split, '.').try(:first) || 'file'
         bytes = ::Base64.decode64 encoded_bytes
 
         super bytes
       end
 
       def original_filename
-        File.basename("file.#{@file_format}")
+        File.basename("#{@file_name}.#{@file_format}")
       end
 
       private


### PR DESCRIPTION
Hello I've added possibility to add custom file_name to uploaded file. I found it quite useful - in my team we had caching issues on mobile side, connected with non-changing file name. Sending additional file name solves this problem.

Regards,
Damian Romanów