### PR TITLE
Should not mutate options[:file_name]

### DIFF
--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -23,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'carrierwave', '>= 0.8.0'
   spec.add_dependency 'mime-types', '~> 3.0'
 
-  spec.add_development_dependency 'rails', '>= 3.2.0'
+  spec.add_development_dependency 'rails', '~> 4'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'mongoid'
   spec.add_development_dependency 'carrierwave-mongoid'

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -18,11 +18,8 @@ module Carrierwave
                                     data.strip.start_with?('data')
 
           options[:file_name] ||= -> { attribute }
-          if options[:file_name].is_a?(Proc) && options[:file_name].arity == 1
-            options[:file_name] = options[:file_name].curry[self]
-          end
           super(Carrierwave::Base64::Base64StringIO.new(
-            data.strip, options[:file_name]
+            data.strip, options[:file_name].call(self)
           ))
         end
         # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -6,7 +6,8 @@ module Carrierwave
       # rubocop:disable Metrics/PerceivedComplexity
       def mount_base64_uploader(attribute, uploader_class, options = {})
         mount_uploader attribute, uploader_class, options
-
+        options[:file_name] ||= -> { attribute }
+        
         define_method "#{attribute}=" do |data|
           return if data == send(attribute).to_s
 
@@ -17,10 +18,13 @@ module Carrierwave
           return super(data) unless data.is_a?(String) &&
                                     data.strip.start_with?('data')
 
-          options[:file_name] ||= -> { attribute }
-          super(Carrierwave::Base64::Base64StringIO.new(
-            data.strip, options[:file_name].call(self)
-          ))
+          filename = if options[:file_name].respond_to?(:call)
+                      options[:file_name].call(self)
+                    else
+                      options[:file_name].to_s
+                    end
+                    
+          super Carrierwave::Base64::Base64StringIO.new(data.strip, filename)
         end
         # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
         # rubocop:enable Metrics/CyclomaticComplexity

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -7,7 +7,7 @@ module Carrierwave
       def mount_base64_uploader(attribute, uploader_class, options = {})
         mount_uploader attribute, uploader_class, options
         options[:file_name] ||= -> { attribute }
-        
+
         define_method "#{attribute}=" do |data|
           return if data == send(attribute).to_s
 
@@ -19,11 +19,11 @@ module Carrierwave
                                     data.strip.start_with?('data')
 
           filename = if options[:file_name].respond_to?(:call)
-                      options[:file_name].call(self)
-                    else
-                      options[:file_name].to_s
-                    end
-                    
+                       options[:file_name].call(self)
+                     else
+                       options[:file_name].to_s
+                     end
+
           super Carrierwave::Base64::Base64StringIO.new(data.strip, filename)
         end
         # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Carrierwave::Base64::Adapter do
       User.mount_base64_uploader(
         :image, uploader, file_name: ->(u) { u.username }
       )
-      User.new
+      User.new(username: 'batman')
     end
 
     let(:mongoid_model) do
@@ -65,6 +65,25 @@ RSpec.describe Carrierwave::Base64::Adapter do
         expect do
           mongoid_model.image = 'test.jpg'
         end.not_to raise_error
+      end
+
+      context 'with additional instances of the mounting class' do
+        let(:another_subject) do
+          another_subject = User.new(username: 'robin')
+          another_subject.image = File.read(
+            file_path('fixtures', 'base64_image.fixture')
+          ).strip
+          another_subject
+        end
+
+        it 'should invoke the file_name proc upon each upload' do
+          subject.save!
+          another_subject.save!
+          another_subject.reload
+          expect(
+            another_subject.image.current_path
+          ).to eq file_path('../uploads', 'robin.jpeg')
+        end
       end
     end
 

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Carrierwave::Base64::Base64StringIO do
-  %w(application/vnd.openxmlformats-officedocument.wordprocessingml.document
-     image/jpeg application/pdf audio/mpeg).each do |content_type|
+  %w[application/vnd.openxmlformats-officedocument.wordprocessingml.document
+     image/jpeg application/pdf audio/mpeg].each do |content_type|
     context "correct #{content_type} data" do
       let(:data) do
         "data:#{content_type};base64,/9j/4AAQSkZJRgABAQEASABKdhH//2Q=="
@@ -22,13 +22,29 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
 
       it 'calls a function that returns the file_name' do
         method = ->(u) { u.username }
-        base64_string_io = described_class.new data, method.curry[User.new]
+        base64_string_io = described_class.new(
+          data, method.curry[User.new(username: 'batman')]
+        )
         expect(base64_string_io.file_name).to eql('batman')
       end
 
       it 'accepts a string as the file name as well' do
         model = described_class.new data, 'string-file-name'
         expect(model.file_name).to eql('string-file-name')
+      end
+
+      it 'issues deprecation warning when string given for file name' do
+        str = ->(u) { u.username }.curry[User.new(username: 'batman')]
+        expect do
+          described_class.new(data, str).file_name
+        end.to warn('Deprecation')
+      end
+
+      it 'does NOT issue deprecation warning when Proc given for file name' do
+        prc = -> { 'String' }
+        expect do
+          described_class.new(data, prc).file_name
+        end.not_to warn('Deprecation')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ ActiveRecord::Base.establish_connection(
 
 load 'support/schema.rb'
 require 'support/models'
+require 'support/custom_expectations/warn_expectation'
 
 def file_path(*paths)
   File.expand_path(File.join(File.dirname(__FILE__), *paths))

--- a/spec/support/custom_expectations/warn_expectation.rb
+++ b/spec/support/custom_expectations/warn_expectation.rb
@@ -1,0 +1,30 @@
+RSpec::Matchers.define :warn do |message|
+  match do |block|
+    fake_stderr(&block).include? message
+  end
+
+  description do
+    "warn \"#{message}\""
+  end
+
+  failure_message_for_should do
+    "expected to #{description}"
+  end
+
+  failure_message_for_should_not do
+    "expected to not #{description}"
+  end
+
+  def fake_stderr
+    original_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original_stderr
+  end
+
+  def supports_block_expectations?
+    true
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,7 +1,5 @@
 class User < ActiveRecord::Base
-  def username
-    'batman'
-  end
+  attr_accessor :username
 end
 
 class MongoidModel


### PR DESCRIPTION
The combination of Proc#curry and the `is_a?(Proc)` conditional create a bug that causes the file name to be set once (the first time a file upload is handled by the Rails process) and then never updated again.

Proc#curry's docs say:

> If a sufficient number of arguments are supplied, it passes the supplied arguments to the original proc and returns the result.

In other words, `curry` does not always return a Proc. Because the Proc's arity is enforced as 1, this means that it will get set to a String after the first run.

This also causes the curious bug of always firing the `file_name` deprecation warning on all but the first request handled by this code.

A better solution is to simply call the proc on demand.