### PR TITLE
Allow setting filename explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ mount_base64_uploader :image, ImageUploader, file_name: 'userpic'
 mount_base64_uploader :image, ImageUploader, file_name: -> { 'userpic' }
 ```
 
+Alternatively file name can be set explicitly when setting the attribute which can be useful in situations when filename is provided along with encoded file. Simply assign a hash (or instance of `ActionController::Parameters`) to attribute instead of string. E.g.
+
+```
+record.image = {
+  data: "data:image/jpeg;base64,(base64 encoded data)",
+  filename: "image.jpeg"
+}
+
 ## Data format
 
 The string with the encoded data, should be prefixed with Data URI scheme format.

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -87,6 +87,26 @@ RSpec.describe Carrierwave::Base64::Adapter do
       end
     end
 
+    context 'base64 string and filename passed in a hash' do
+      before(:each) do
+        subject.image = {
+          data: File.read(
+            file_path('fixtures', 'base64_image.fixture')
+          ).strip,
+          file_name: 'image.jpeg'
+        }
+      end
+
+      it 'creates a file' do
+        subject.save!
+        subject.reload
+
+        expect(
+          subject.image.current_path
+        ).to eq file_path('../uploads', 'image.jpeg')
+      end
+    end
+
     context 'stored uploads exist for the field' do
       before :each do
         subject.image = File.read(


### PR DESCRIPTION
Added ability to pass hash to the attribute.

The use case is when the original filename is explicitely provided along with the encoded file.

This is sometimes the case in JS frontends that handle uploads by reading the file with `FileReader` object provided by the modern browsers and then sending the value via API to their backends. The frontend piece also have access to the original filename, so it can send it along with data, which would result in proper filename saved on the server.