### PR TITLE
Raise deprecation warning on adapter instead of Base64StringIO.

### DIFF
--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -8,6 +8,14 @@ module Carrierwave
         mount_uploader attribute, uploader_class, options
         options[:file_name] ||= proc { attribute }
 
+        if options[:file_name].is_a?(String)
+          warn(
+            '[Deprecation warning] Setting `file_name` option to a string is '\
+            'deprecated and will be removed in 3.0.0. If you want to keep the '\
+            'existing behaviour, wrap the string in a Proc'
+          )
+        end
+
         define_method "#{attribute}=" do |data|
           return if data == send(attribute).to_s
 
@@ -21,8 +29,8 @@ module Carrierwave
           filename = if options[:file_name].respond_to?(:call)
                        options[:file_name].call(self)
                      else
-                       options[:file_name].to_s
-                     end
+                       options[:file_name]
+                     end.to_s
 
           super Carrierwave::Base64::Base64StringIO.new(data.strip, filename)
         end

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -5,13 +5,13 @@ module Carrierwave
 
       attr_accessor :file_extension, :file_name
 
-      def initialize(encoded_file, file_name_proc_or_string)
+      def initialize(encoded_file, file_name)
         description, encoded_bytes = encoded_file.split(',')
 
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?('(null)')
 
-        @file_name = extract_file_name(file_name_proc_or_string)
+        @file_name = file_name
         @file_extension = get_file_extension description
         bytes = ::Base64.decode64 encoded_bytes
 
@@ -31,19 +31,6 @@ module Carrierwave
           raise ArgumentError, "Unknown MIME type: #{content_type}"
         end
         mime_type.preferred_extension
-      end
-
-      def extract_file_name(proc_or_string)
-        if proc_or_string.is_a?(Proc)
-          proc_or_string.call
-        else
-          warn(
-            '[Deprecation warning] Setting `file_name` option to a string is '\
-            'deprecated and will be removed in 3.0.0. If you want to keep the '\
-            'existing behaviour, wrap the string in a Proc'
-          )
-          proc_or_string
-        end
       end
     end
   end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe Carrierwave::Base64::Adapter do
         expect(subject.image).to be_an_instance_of(uploader)
       end
 
+      context 'when file_name is a string' do
+        it 'issues a deprecation warning' do
+          expect do
+            User.mount_base64_uploader(
+              :image, uploader, file_name: 'file_name'
+            )
+          end.to warn('Deprecation')
+        end
+      end
+
+      context 'when file_name is a proc' do
+        it 'does NOT issue a deprecation warning' do
+          expect do
+            User.mount_base64_uploader(
+              :image, uploader, file_name: ->(u) { u.username }
+            )
+          end.not_to warn('Deprecation')
+        end
+      end
+
       context 'normal file uploads' do
         before(:each) do
           sham_rack_app = ShamRack.at('www.example.com').stub

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -32,20 +32,6 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
         model = described_class.new data, 'string-file-name'
         expect(model.file_name).to eql('string-file-name')
       end
-
-      it 'issues deprecation warning when string given for file name' do
-        str = ->(u) { u.username }.curry[User.new(username: 'batman')]
-        expect do
-          described_class.new(data, str).file_name
-        end.to warn('Deprecation')
-      end
-
-      it 'does NOT issue deprecation warning when Proc given for file name' do
-        prc = -> { 'String' }
-        expect do
-          described_class.new(data, prc).file_name
-        end.not_to warn('Deprecation')
-      end
     end
   end
 


### PR DESCRIPTION
Currently, I'm getting the warning even when I set up file_name as a proc:

```
mount_base64_uploader :avatar, UserAvatarUploader, file_name: ->(_) { SecureRandom.hex(8) }
```

In order to fix the warning at the moment, you have to do this:

```
mount_base64_uploader :avatar, UserAvatarUploader, file_name: ->(_) { -> { SecureRandom.hex(8) } }
```

I don't think the latter is intended to do