### PR TITLE
Raise error whitespace base64 string

### DIFF
--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -10,10 +10,10 @@ module Carrierwave
 
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?('(null)')
-        
+
         if encoded_bytes.match(/\s/).present?
-          raise ArgumentError, "Base64 string cannot contain whitespace"
-        end  
+          raise ArgumentError, 'Base64 string cannot contain whitespace'
+        end
 
         @file_name = file_name
         @file_extension = get_file_extension description

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -10,6 +10,10 @@ module Carrierwave
 
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?('(null)')
+        
+        if encoded_bytes.match(/\s/).present?
+          raise ArgumentError, "Base64 string cannot contain whitespace"
+        end  
 
         @file_name = file_name
         @file_extension = get_file_extension description

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -8,9 +8,6 @@ module Carrierwave
       def initialize(encoded_file, file_name)
         description, encoded_bytes = encoded_file.split(',')
 
-        raise ArgumentError unless encoded_bytes
-        raise ArgumentError if encoded_bytes.eql?('(null)')
-
         @file_name = file_name
         @file_extension = get_file_extension description
         bytes = ::Base64.strict_decode64 encoded_bytes

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -11,13 +11,9 @@ module Carrierwave
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?('(null)')
 
-        if encoded_bytes.match(/\s/).present?
-          raise ArgumentError, 'Base64 string cannot contain whitespace'
-        end
-
         @file_name = file_name
         @file_extension = get_file_extension description
-        bytes = ::Base64.decode64 encoded_bytes
+        bytes = ::Base64.strict_decode64 encoded_bytes
 
         super bytes
       end

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -47,5 +47,11 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
         described_class.new('data:image/jpeg;base64,(null)', 'file')
       end.to raise_error(Carrierwave::Base64::Base64StringIO::ArgumentError)
     end
+
+    it 'raises ArgumentError if base64 data contains white space' do
+      expect do
+        described_class.new("data:image/jpeg;base64,/9j/4AAQSk ZJRgABA QEASABKdhH//2Q==")
+      end.to raise_error(Carrierwave::Base64::Base64StringIO::ArgumentError)
+    end
   end
 end

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
 
     it 'raises ArgumentError if base64 data contains white space' do
       expect do
-        described_class.new("data:image/jpeg;base64,/9j/4AAQSk ZJRgABA QEASABKdhH//2Q==")
+        data = "data:image/jpeg;base64,/9j/4AAQSk ZJRgABA QEASABKdhH//2Q=="
+        described_class.new data, "file"
       end.to raise_error(Carrierwave::Base64::Base64StringIO::ArgumentError)
     end
   end

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
 
     it 'raises ArgumentError if base64 data contains white space' do
       expect do
-        data = "data:image/jpeg;base64,/9j/4AAQSk ZJRgABA QEASABKdhH//2Q=="
-        described_class.new data, "file"
+        data = 'data:image/jpeg;base64,/9j/4AAQSk ZJRgABA QEASABKdhH//2Q=='
+        described_class.new data, 'file'
       end.to raise_error(Carrierwave::Base64::Base64StringIO::ArgumentError)
     end
   end

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
     it 'raises ArgumentError if base64 data eql (null)' do
       expect do
         described_class.new('data:image/jpeg;base64,(null)', 'file')
-      end.to raise_error(Carrierwave::Base64::Base64StringIO::ArgumentError)
+      end.to raise_error(ArgumentError, 'invalid base64')
     end
 
     it 'raises ArgumentError if base64 data contains white space' do

--- a/spec/base64_string_io_spec.rb
+++ b/spec/base64_string_io_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
      image/jpeg application/pdf audio/mpeg].each do |content_type|
     context "correct #{content_type} data" do
       let(:data) do
-        "data:#{content_type};base64,/9j/4AAQSkZJRgABAQEASABKdhH//2Q=="
+        "data:#{content_type};base64,VGhpcyBpcyB0ZXN0IHN0cmluZw=="
       end
 
       let(:file_extension) do
@@ -50,9 +50,9 @@ RSpec.describe Carrierwave::Base64::Base64StringIO do
 
     it 'raises ArgumentError if base64 data contains white space' do
       expect do
-        data = 'data:image/jpeg;base64,/9j/4AAQSk ZJRgABA QEASABKdhH//2Q=='
+        data = 'data:image/jpeg;base64,VGhpcyBpc yB0Z XN0 IHN0 cmluZw=='
         described_class.new data, 'file'
-      end.to raise_error(Carrierwave::Base64::Base64StringIO::ArgumentError)
+      end.to raise_error(ArgumentError, 'invalid base64')
     end
   end
 end


### PR DESCRIPTION
Raising an error if the Base64 string contains any whitespace.