### PR TITLE
Moved Railtie code so it can be used in non Rails apps/gems

### DIFF
--- a/lib/carrierwave/base64.rb
+++ b/lib/carrierwave/base64.rb
@@ -3,18 +3,9 @@ require 'carrierwave/base64/version'
 require 'carrierwave/base64/exceptions'
 require 'carrierwave/base64/base64_string_io'
 require 'carrierwave/base64/adapter'
+require 'carrierwave/base64/railtie' if defined?(Rails)
 
 module Carrierwave
   module Base64
-    class Railtie < Rails::Railtie
-      ActiveSupport.on_load :active_record do
-        ActiveRecord::Base.extend Carrierwave::Base64::Adapter
-      end
-
-      ActiveSupport.on_load :mongoid do
-        Mongoid::Document::ClassMethods.send :include,
-                                             Carrierwave::Base64::Adapter
-      end
-    end
   end
 end

--- a/lib/carrierwave/base64/railtie.rb
+++ b/lib/carrierwave/base64/railtie.rb
@@ -1,0 +1,14 @@
+module Carrierwave
+  module Base64
+    class Railtie < Rails::Railtie
+      ActiveSupport.on_load :active_record do
+        ActiveRecord::Base.extend Carrierwave::Base64::Adapter
+      end
+
+      ActiveSupport.on_load :mongoid do
+        Mongoid::Document::ClassMethods.send :include,
+                                             Carrierwave::Base64::Adapter
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moved Railtie code into its own class file so that the gem can be used in non Rails apps, as outlined in the [Rails Railtie's source](https://github.com/rails/rails/blob/master/railties/lib/rails/railtie.rb#L38)