### PR TITLE
Fixed sqlite3 dependency version with rails 8.0.2

### DIFF
--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'sham_rack'
-  spec.add_development_dependency 'sqlite3', '~> 1.7.3'
+  spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
Details see in the [issue](https://github.com/y9v/carrierwave-base64/issues/91).